### PR TITLE
Fix: Correct parameter name from 'slug' to 'alias' in Product component

### DIFF
--- a/traino/app/trainer/Product.jsx
+++ b/traino/app/trainer/Product.jsx
@@ -19,7 +19,7 @@ export default function IdPage({ params, onClose = null, nav = true }) {
   const router = useRouter();
 
   // Access dynamic segments from params
-  const userAliasDecoded = decodeURIComponent(params.slug); // e.g., "fredrikberglund"
+  const userAliasDecoded = decodeURIComponent(params.alias); // e.g., "fredrikberglund"
   const userAlias = userAliasDecoded.substring(1);
   const sport = params.sport; // e.g., "cs2"
   const productType = params.products; // e.g., "dietprogram"


### PR DESCRIPTION
Fixade så "välj" på tränarsidan inte retunerar ett 404 error