### PR TITLE
fix: prevent infinite map scrolling by adding maxBounds and maxBoundsViscosity

### DIFF
--- a/traino/app/train/[sport]/Map.jsx
+++ b/traino/app/train/[sport]/Map.jsx
@@ -991,6 +991,8 @@ export default function Map({
           zoom={userZoom || 14}
           style={{ width: '100%', height: '100%' }}
           whenCreated={handleMapCreated}
+          maxBounds={[[ -85, -180 ], [ 85, 180 ]]}
+          maxBoundsViscosity={1.0}
         >
           <TileLayer url={mapCnf.leafletTileUrlTemplate} attribution={mapCnf.leafletAttribution} />
           <MapEvents />


### PR DESCRIPTION
This pull request makes a small but important update to the map component to restrict the panning area and improve user experience.

Map boundary restriction:

* The `Map` component in `Map.jsx` now sets `maxBounds` and `maxBoundsViscosity` to prevent users from panning the map outside of valid latitude and longitude ranges, keeping the map view constrained to the world map. ([traino/app/train/[sport]/Map.jsxR994-R995](diffhunk://#diff-752d4cfc7db483bb30ac256c6a368752334a2014cdecba1fe126640a50922871R994-R995))